### PR TITLE
Migrate from request to axios http client

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -13,6 +13,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
 
+require('es6-promise').polyfill();
 var axios = require('axios');
 
 /**

--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -13,7 +13,7 @@
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
 
-var request = require('request');
+var axios = require('axios');
 
 /**
  * Create an emitter object which will send events to a collector
@@ -43,21 +43,38 @@ function emitter(endpoint, protocol, port, method, bufferSize, callback) {
 		var temp = buffer;
 		buffer = [];
 		if (method === 'post') {
-			var postJson = {
-				schema: 'iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-0',
-				data: temp.map(valuesToStrings)
-			};
-			request.post({
+			var postData = {
 				url: targetUrl,
-				json: postJson,
+				method: 'post',
 				headers: {
 					'content-type': 'application/json; charset=utf-8'
+				},
+				data: {
+					schema: 'iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-2',
+					data: temp.map(valuesToStrings)
 				}
-			}, callback);
+			}
+
+			axios(postData)
+				.then(function(response) {
+					onSuccess(response, callback);
+				})
+				.catch(function(error) {
+					onFailure(error, callback);
+				})
 
 		} else {
-			for (var i=0; i<temp.length; i++) {
-				request.get({url: targetUrl, qs: temp[i]}, callback);
+			for (var i = 0; i < temp.length; i++) {
+				axios.get(targetUrl, {
+					params: temp[i]
+				})
+				.then(function(response) {
+					onSuccess(response, callback);
+				})
+				.catch(function(error) {
+					onFailure(error, callback);
+				});
+
 			}
 		}
 	}
@@ -86,6 +103,22 @@ function valuesToStrings(payload) {
 		}
 	}
 	return stringifiedPayload;
+}
+
+function onSuccess(response, cb) {
+	cb(undefined, response, response.data);
+}
+
+function onFailure(error, cb) {
+	var response, body;
+	if (error.response) {
+		response = error.response;
+
+		if (error.response.data) {
+			body = error.response.data
+		}
+	}
+	cb(error, response, body);
 }
 
 module.exports = emitter;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "license": "Apache 2.0",
   "dependencies": {
     "axios": "^0.16.0",
-    "request": "^2.39.0",
     "snowplow-tracker-core": "^0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "license": "Apache 2.0",
   "dependencies": {
+    "axios": "^0.16.0",
     "request": "^2.39.0",
     "snowplow-tracker-core": "^0.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
     "test-travis": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -R spec ./test/*"
   },
   "devDependencies": {
-    "mocha": "^1.21.3",
-    "nock": "^0.44.0",
+    "coveralls": "~2.11.4",
+    "es6-promise": "^4.1.0",
     "istanbul": "~0.3.20",
-    "coveralls": "~2.11.4"
+    "mocha": "^1.21.3",
+    "nock": "^0.44.0"
   },
   "contributors": [
     "Fred Blundun"

--- a/test/tracker.js
+++ b/test/tracker.js
@@ -54,7 +54,7 @@ function getMock(method) {
 
 function extractPayload(response, method) {
 	if (method === 'get') {
-		return JSON.parse(response);
+		return response;
 	}
 	else {
 		return response.data[0];


### PR DESCRIPTION
Related to https://github.com/snowplow/snowplow/issues/3182.
Axios is http client with ability to run under different
environments such as browser or node. Axios is promise based but emitter
still takes single callback function due to the backward compatibility.