### PR TITLE
Update flush to not send a request if the buffer is empty

### DIFF
--- a/lib/emitter.js
+++ b/lib/emitter.js
@@ -43,6 +43,10 @@ function emitter(endpoint, protocol, port, method, bufferSize, callback, agentOp
 	function flush() {
 		var temp = buffer;
 		buffer = [];
+		if (temp.length === 0) {
+			return
+		}
+
 		if (method === 'post') {
 			var postJson = {
 				schema: 'iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-0',
@@ -61,8 +65,8 @@ function emitter(endpoint, protocol, port, method, bufferSize, callback, agentOp
 			for (var i=0; i<temp.length; i++) {
 				request.get({
 					url: targetUrl,
-                    agentOptions: agentOptions,
-				 	qs: temp[i]
+					agentOptions: agentOptions,
+					qs: temp[i]
 				}, callback);
 			}
 		}

--- a/test/emitter.js
+++ b/test/emitter.js
@@ -86,5 +86,11 @@ describe('emitter', function () {
 			done();
 		});
 
+		it('should not send requests if the buffer is empty', function(done) {
+			var e = emitter(endpoint, 'https', null, 'post', null, done);
+			e.flush();
+			done();
+		})
+
 	});
 });


### PR DESCRIPTION
`com.snowplowanalytics.snowplow/payload_data` considers an empty array `data` as an error.

This updates `flush` so it doesn't send anything if theres nothing in the buffer.