### PR TITLE
Bump core tracker version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "license": "Apache 2.0",
   "dependencies": {
     "request": "^2.81.0",
-    "snowplow-tracker-core": "^0.5.0"
+    "snowplow-tracker-core": "^0.7.2"
   }
 }


### PR DESCRIPTION
There have been many updates to the core tracker that I would like to take advantage on. Since the tracker is on 0.x.x a bump of the second digit is considered a major bump so currently this package only gets 0.5.x