### PR TITLE
Release/0.4.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 0.4.2 (2020-09-28)
+--------------------------
+Bump got to 11.7.0 (#67)
+Bump tsconfig target to match got (#66)
+
 Version 0.4.1 (2020-09-18)
 --------------------------
 Bump snowplow-tracker-core to 0.9.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -3458,18 +3458,18 @@
       }
     },
     "got": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.5.2.tgz",
-      "integrity": "sha512-yUhpEDLeuGiGJjRSzEq3kvt4zJtAcjKmhIiwNp/eUs75tRlXfWcHo5tcBaMQtnjHWC7nQYT5HkY/l0QOQTkVww==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
+      "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
       "requires": {
-        "@sindresorhus/is": "^3.0.0",
+        "@sindresorhus/is": "^3.1.1",
         "@szmarczak/http-timer": "^4.0.5",
         "@types/cacheable-request": "^6.0.1",
         "@types/responselike": "^1.0.0",
         "cacheable-lookup": "^5.0.3",
         "cacheable-request": "^7.0.1",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
         "p-cancelable": "^2.0.0",
         "responselike": "^2.0.0"
@@ -4041,9 +4041,9 @@
       "dev": true
     },
     "keyv": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
-      "integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
       "requires": {
         "json-buffer": "3.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "got": "^11.5.2",
+    "got": "^11.7.0",
     "snowplow-tracker-core": "^0.9.2",
     "tslib": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es2017",                       /* Good for Node 8 - https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping */
+    "lib": ["es2018"],
+    "target": "es2018",                       /* Good for Node 10 - https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping */
     "module": "commonjs",                     /* Ignored by rollup but used by ts-node for tests */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
 


### PR DESCRIPTION
got targets ES2018 which means having ES2017 as our target is a little pointless since the only available emitter uses got. This bumps the typescript target to ES2018 for the tracker and bumps got to the latest release. This is an attempt to fix a type issue being exhibited in a client application.