### PR TITLE
Release/0.4.3

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,3 +15,4 @@ jobs:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
         command: monitor
+        args: --project-name=snowplow-nodejs-tracker

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 0.4.3 (2020-10-10)
+--------------------------
+Bump snowplow-tracker-core to 0.9.3 (#70)
+Update Snyk to monitor project `snowplow-nodejs-tracker` (#69)
+
 Version 0.4.2 (2020-09-28)
 --------------------------
 Bump got to 11.7.0 (#67)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5579,9 +5579,9 @@
       }
     },
     "snowplow-tracker-core": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/snowplow-tracker-core/-/snowplow-tracker-core-0.9.2.tgz",
-      "integrity": "sha512-ldMFUP6NFdOFxh7DtatZ7k0Z06iTWCjkQPC8BWHLXfwz4H3aTHNiRlb1BVpmRbQEhF0yzUZ5WOsly+xi/dI1EA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/snowplow-tracker-core/-/snowplow-tracker-core-0.9.3.tgz",
+      "integrity": "sha512-supvM1NeXCPCHMequi39W1GB/dd3ROvzA81kHEKv0oRrwc53LHv+u4Dk0mdFsNLZtBeTmHniKMrsjUxoCJ3ZIg==",
       "requires": {
         "lodash": "^4.17.20",
         "tslib": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "got": "^11.7.0",
-    "snowplow-tracker-core": "^0.9.2",
+    "snowplow-tracker-core": "^0.9.3",
     "tslib": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snowplow-tracker",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Fixes a collision in the Snyk UI between the JavaScript Tracker and Nodejs Tracker as both are called `snowplow-tracker` in  `package.json`.